### PR TITLE
修复: 支持空文本翻译场景，避免AI翻译报错

### DIFF
--- a/Editor/LLMAI/LLMAIService.cs
+++ b/Editor/LLMAI/LLMAIService.cs
@@ -91,6 +91,13 @@ namespace CardGame.Editor.LLMAI
             string userPromptOverride = null,
             string additionalContext = null)
         {
+            // 如果文本为空，直接返回空字符串而不进行翻译
+            if (string.IsNullOrEmpty(text))
+            {
+                Debug.Log($"[AI翻译] 跳过空文本翻译，本地化Key: {localizationKey}");
+                return string.Empty;
+            }
+
             string userPrompt = userPromptOverride ?? text;
             string systemPrompt = systemPromptOverride ?? $"You are a PC card game professional translator. Translate the following text to {targetLanguage}.";
 

--- a/Editor/LLMAI/LocalizationTranslatorWindow.cs
+++ b/Editor/LLMAI/LocalizationTranslatorWindow.cs
@@ -616,6 +616,13 @@ namespace CardGame.Editor.LLMAI
 
                 if (string.IsNullOrEmpty(translatedText))
                 {
+                    // 如果源文本为空，则空的翻译结果是合理的
+                    if (string.IsNullOrEmpty(task.sourceText))
+                    {
+                        // 在主线程中更新翻译结果(空字符串)
+                        await UpdateTranslationResult(task, string.Empty, processedTasks);
+                        return;
+                    }
                     throw new Exception("翻译结果为空");
                 }
 


### PR DESCRIPTION
在LLMAIService.TranslateText方法中添加空文本检查，跳过空文本翻译请求
在ProcessTranslationTask中优化对空翻译结果的处理逻辑
当源文本为空时自动返回空字符串，无需调用API